### PR TITLE
QUIT :lost_terminal 시 segmentation fault 발생

### DIFF
--- a/data/UserData.cpp
+++ b/data/UserData.cpp
@@ -92,8 +92,8 @@ void UserData::delete_user(const User& user) {
 		map<int, UserIter>::iterator socket_found = user_socket_map.find(user.get_connection().socket_fd);;
 		map<string, UserIter>::iterator nick_found = user_nick_map.find(user.get_nickname());
 		user_socket_map.erase(socket_found);
-		user_nick_map.erase(nick_found);
 		users.erase(nick_found->second);
+		user_nick_map.erase(nick_found);
 	}
 	else {
 		users.remove(user);


### PR DESCRIPTION
## 변경점
quit 시, 정보 삭제 순서 변경

## 스크린샷(선택)
<img width="264" alt="스크린샷 2023-12-05 오후 10 17 13" src="https://github.com/nyj001012/ft_irc/assets/50291995/75670ca1-f430-4e11-86ce-f104ef742e8b">

- 정상적으로 삭제됨

## 테스트 내용 (선택)

## 점검
- [x] C++98 함수 사용
- [x] Leaks